### PR TITLE
Update Stylus to 0.47.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "enb stylus techs",
   "dependencies": {
     "vow": "~0.3.12",
-    "stylus": "0.46.x",
+    "stylus": "0.47.1",
     "autoprefixer": "1.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Stylus version should be hardy fixed because of bugs and incompatibilities even between patch versions.
