### PR TITLE
update autoprefixer - version 3.1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "vow": "0.4.7",
     "stylus": "0.47.1",
-    "autoprefixer": "1.0.x"
+    "autoprefixer": "~3.1.0"
   },
   "devDependencies": {
     "enb": "~0.8.43",

--- a/techs/css-stylus-with-autoprefixer.js
+++ b/techs/css-stylus-with-autoprefixer.js
@@ -35,7 +35,7 @@ module.exports = require('./css-stylus').buildFlow()
             renderer.use(function (style) {
                 this.on('end', function (err, css) {
                     return args ?
-                        autoprefixer.apply(this, args).process(css).css :
+                        autoprefixer.apply(this, {browsers: args}).process(css).css :
                         autoprefixer.process(css).css;
                 });
             });


### PR DESCRIPTION
Теперь autoprefixer ожидает объект в качестве аргумента, а не массив.
Посмотрел в своем проекте - внешне все хорошо + починилась проблема с -moz-user-select
