### PR TITLE
Allow the use of all autoprefixer options

### DIFF
--- a/techs/stylus.js
+++ b/techs/stylus.js
@@ -360,8 +360,8 @@ module.exports = buildFlow.create()
             if (this._autoprefixer) {
                 var autoprefixer = require('autoprefixer');
                 processor.use(
-                    (this._autoprefixer.browsers ?
-                        autoprefixer({ browsers: this._autoprefixer.browsers }) :
+                    (typeof this._autoprefixer === 'object' ?
+                        autoprefixer(this._autoprefixer) :
                         autoprefixer)
                 );
             }


### PR DESCRIPTION
There is no way currently to pass external stats file to autoprefixer, since everything except `browsers` property is omitted. I wanted to setup it like so:
```
[require('enb-stylus/techs/stylus'), {
	autoprefixer: {
		browsers: [
			'> 0.5% in my stats'
		],
		stats: myCustomStat
	}
}]
```
This PR solves this issue.