### PR TITLE
Fix tests for newer npm and simplify imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "es6-promise": "4.0.5",
     "nib": "1.1.2",
     "postcss": "5.2.15",
-    "postcss-import": "7.1.3",
     "postcss-url": "5.1.2",
     "stylus": "0.54.5",
     "vow": "0.4.15"

--- a/techs/stylus.js
+++ b/techs/stylus.js
@@ -35,8 +35,8 @@ var path = require('path'),
  *                                                                    - `inline` – inlines assets using base64 encoding.
  * @param {Boolean}         [options.comments=true]                   Adds CSS comment with path to source to a code
  *                                                                    block (above and below).<br/>
- * @param {String|Boolean}  [options.imports='include']               Allows to include(expand) @import or leave without
- *                                                                    changes.
+ * @param {String|Boolean}  [options.imports='include']               Allows to include(expand) @import with css files
+ *                                                                    or leave without changes.
  * @param {Boolean|String}  [options.sourcemap=false]                 Builds sourcemap:<br/>
  *                                                                    - `true` – builds ?.css.map.<br/>
  *                                                                    - `inline` – builds and inlining sourcemap into
@@ -275,6 +275,7 @@ module.exports = buildFlow.create()
             var renderer = stylus(stylesImports)
                 .set('prefix', this._prefix)
                 .set('filename', filename)
+                .set('include css', this._imports === 'include')
                 .set('sourcemap', map);
 
             // rebase url() in all cases on stylus level
@@ -345,11 +346,6 @@ module.exports = buildFlow.create()
                     inline: this._sourcemap === 'inline',
                     annotation: true
                 };
-            }
-
-            // expand imports with css
-            if (this._imports === 'include') {
-                processor.use(require('postcss-import')());
             }
 
             // rebase or inline urls in css

--- a/test/stylus-native-tests.js
+++ b/test/stylus-native-tests.js
@@ -12,10 +12,7 @@ var fs = require('fs'),
     stylusDir = path.join(__dirname, 'fixtures', 'stylus', 'test'),
     casesMock = mockFsHelper.duplicateFSInMemory(path.join(stylusDir, 'cases')),
     imagesMock = mockFsHelper.duplicateFSInMemory(path.join(stylusDir, 'images')),
-    stylus = mockFsHelper.duplicateFSInMemory(path.join(__dirname, 'fixtures', 'stylus')),
-    postcss = mockFsHelper.duplicateFSInMemory(path.resolve('node_modules', 'postcss')),
-    postcssImport = mockFsHelper.duplicateFSInMemory(path.resolve('node_modules', 'postcss-import')),
-    postcssUrl = mockFsHelper.duplicateFSInMemory(path.resolve('node_modules', 'postcss-url')),
+    nodeModules = mockFsHelper.duplicateFSInMemory(path.resolve('node_modules')),
     stylusCasesIgnores = [
         // File is`t included in the test cases
         'index',
@@ -74,12 +71,7 @@ addSuite('cases', readDir(stylusDir + '/cases', '.styl'), function (test, done) 
             cases: casesMock,
             images: imagesMock,
             // jscs:disable
-            node_modules: {
-                stylus: stylus,
-                postcss: postcss,
-                'postcss-import': postcssImport,
-                'postcss-url': postcssUrl
-            }
+            node_modules: nodeModules
             // jscs:enable
         };
 


### PR DESCRIPTION
* Fixed tests with newer npm versions (3+)
* Added several new tests for import (v2.3.0 regression)
* Simplified `imports` option - now uses stylus built-in flag instead of external `postcss-import` module