### PR TITLE
Allow to use postcss plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ module.exports = function(config) {
             // sourceSuffixes: ['.styl', '.css'],
             // url: 'rebase'
             // imports: 'include',
-            // comments: true
+            // comments: true,
+            // plugins: []
         }]);
         node.addTarget('?.css');
     });

--- a/techs/stylus.js
+++ b/techs/stylus.js
@@ -91,6 +91,7 @@ var path = require('path'),
 module.exports = buildFlow.create()
     .name('stylus')
     .target('target', '?.css')
+    .defineOption('plugins', [])
     .defineOption('url', 'rebase')
     .defineOption('inlineMaxSize', 14)
     .defineOption('comments', true)
@@ -321,7 +322,7 @@ module.exports = buildFlow.create()
          */
         _processCss: function (filename, css, sourcemap) {
             var postcss = require('postcss'),
-                postcssPlugins = [],
+                postcssPlugins = this._plugins,
                 urlMethod = this._url,
 
                 // base opts to resolve urls


### PR DESCRIPTION
This PR add support to add postcss plugins array like enb-postcss. It is useful to add some custom plugins like lostgrid.
Example usage:

```js
 [techs.css.stylus, {
      sourceSuffixes : ['css', 'styl'],
      autoprefixer : true,
      plugins : [require('lost')()]
 }],
```